### PR TITLE
Give ExplosionSource a single owner for the size default

### DIFF
--- a/server/block/bed.go
+++ b/server/block/bed.go
@@ -107,7 +107,7 @@ func (b Bed) Activate(pos cube.Pos, _ cube.Face, tx *world.Tx, u item.User, _ *i
 			SpawnFire: true,
 		}.Explode(tx, world.BlockExplosionSource{
 			Block:         b,
-			Pos:           pos.Vec3Centre(),
+			Pos:           pos,
 			ExplosionSize: 5,
 		})
 		return true

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -14,8 +14,8 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// ExplosionConfig is the configuration for an explosion. The world, position, size, sound, particle, and more can all
-// be configured through this configuration.
+// ExplosionConfig is the configuration for an explosion. The sound, particle, item drop chance and more can all be
+// configured through this configuration. The position and size come from the world.ExplosionSource passed to Explode.
 type ExplosionConfig struct {
 	// RandSource is the source to use for the explosion "randomness". If set
 	// to nil, RandSource defaults to a `rand.PCG`source seeded with
@@ -39,14 +39,13 @@ type ExplosionConfig struct {
 
 // ExplodableEntity represents an entity that can be exploded.
 type ExplodableEntity interface {
-	// Explode is called when an explosion occurs. The entity can then react to the explosion using the configuration
-	// and impact provided.
+	// Explode is called when an explosion occurs. The entity can react using the source and impact provided.
 	Explode(src world.ExplosionSource, impact float64)
 }
 
 // Explodable represents a block that can be exploded.
 type Explodable interface {
-	// Explode is called when an explosion occurs. The block can react to the explosion using the configuration passed.
+	// Explode is called when an explosion occurs. The block can react using the source and configuration passed.
 	Explode(src world.ExplosionSource, pos cube.Pos, tx *world.Tx, c ExplosionConfig)
 }
 
@@ -79,14 +78,10 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 		t := uint64(time.Now().UnixNano())
 		c.RandSource = rand.NewPCG(t, t)
 	}
-	size := src.Size()
-	if size == 0 {
-		size = 4
-	}
+	size, explosionPos := src.Size(), src.Position()
 	if c.ItemDropChance == 0 {
 		c.ItemDropChance = 1.0 / size
 	}
-	explosionPos := src.Position()
 
 	r, d := rand.New(c.RandSource), size*2
 	box := cube.Box(

--- a/server/world/explosion.go
+++ b/server/world/explosion.go
@@ -1,18 +1,26 @@
 package world
 
 import (
+	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// ExplosionSource represents the source of the explosion.
+// defaultExplosionSize is the size used if a source does not specify one.
+const defaultExplosionSize = 4
+
+// ExplosionSource represents the source of an explosion.
 type ExplosionSource interface {
+	// Position returns the position at the centre of the explosion.
 	Position() mgl64.Vec3
+	// Size returns the radius which entities/blocks are affected within.
 	Size() float64
 }
 
-// EntityExplosionSource is used for explosion caused by entity.
+// EntityExplosionSource is used for an explosion caused by an entity.
 type EntityExplosionSource struct {
-	Entity        Entity
+	// Entity is the entity that caused the explosion.
+	Entity Entity
+	// ExplosionSize is the size of the explosion. Defaults to 4 if 0.
 	ExplosionSize float64
 }
 
@@ -23,22 +31,31 @@ func (e EntityExplosionSource) Position() mgl64.Vec3 {
 
 // Size ...
 func (e EntityExplosionSource) Size() float64 {
+	if e.ExplosionSize == 0 {
+		return defaultExplosionSize
+	}
 	return e.ExplosionSize
 }
 
-// BlockExplosionSource is used for explosion caused by block.
+// BlockExplosionSource is used for an explosion caused by a block.
 type BlockExplosionSource struct {
-	Block         Block
-	Pos           mgl64.Vec3
+	// Block is the block that caused the explosion.
+	Block Block
+	// Pos is the position of the block that caused the explosion.
+	Pos cube.Pos
+	// ExplosionSize is the size of the explosion. Defaults to 4 if 0.
 	ExplosionSize float64
 }
 
 // Position ...
 func (b BlockExplosionSource) Position() mgl64.Vec3 {
-	return b.Pos
+	return b.Pos.Vec3Centre()
 }
 
 // Size ...
 func (b BlockExplosionSource) Size() float64 {
+	if b.ExplosionSize == 0 {
+		return defaultExplosionSize
+	}
 	return b.ExplosionSize
 }


### PR DESCRIPTION
Follow-up to df-mc/dragonfly#1343 — I like the direction (`ExplosionConfig` was the wrong home for "what exploded", and carrying the source into `ExplosionDamageSource` is a real gain), so here are a few things I hit reading through it. Merge, cherry-pick or ignore as you like.

### The size default has two owners

`ExplosionConfig.Explode` normalised a zero size into a local `size`, but `src` was passed downstream unchanged, and `Player.Explode` reads `src.Size()` directly for the damage multiplier:

```go
p.Hurt(math.Floor((impact*impact+impact)*3.5*src.Size()*2+1), ...)
```

So a source built without an explicit size exploded with a radius of 4 but only ever dealt `math.Floor(0+1)` = 1 damage, at any distance. That was primed TNT until your `ExplosionSize: 4` commit; it's still reachable by anyone constructing a source without a size, and the radius/damage disagreement is easy to miss because the blast itself looks correct.

Moved the `0 → 4` fallback into `Size()` on both sources, so the radius, the item drop chance and the damage all come from one value, and dropped the normalisation in `Explode`.

### `BlockExplosionSource.Pos` is now a `cube.Pos`

A block explosion is inherently block-positioned and `world` already imports `cube`. As it was, a handler got the `Block` but had to reverse-derive the coordinates from a centred `Vec3`. `Position()` centres it instead, so `bed.go` just passes `pos`.

### Docs

Added short doc comments on `ExplosionSource`'s methods and the fields of both source types. Also refreshed two stale comments: `ExplosionConfig` still advertised a configurable size, and `ExplodableEntity.Explode` still referred to a configuration it no longer receives.

### Left alone

`Explodable` still takes an `ExplosionConfig` while `ExplodableEntity` no longer does. With `Size` gone what reaches blocks is only `RandSource`/`Sound`/`Particle`/`SpawnFire`/`ItemDropChance`, and the sole in-tree implementor (`block.TNT`) ignores it — so it's arguably droppable from both, or worth keeping on both. That's your call, so I didn't touch it.

`gofmt`, `go vet ./server/...` and `go test ./...` are all clean.