### PR TITLE
Drop ExplosionConfig from Explodable

### DIFF
--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -45,8 +45,8 @@ type ExplodableEntity interface {
 
 // Explodable represents a block that can be exploded.
 type Explodable interface {
-	// Explode is called when an explosion occurs. The block can react using the source and configuration passed.
-	Explode(src world.ExplosionSource, pos cube.Pos, tx *world.Tx, c ExplosionConfig)
+	// Explode is called when an explosion occurs. The block can react using the source passed.
+	Explode(src world.ExplosionSource, pos cube.Pos, tx *world.Tx)
 }
 
 // rays ...
@@ -145,7 +145,7 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	for _, pos := range affectedBlocks {
 		bl := tx.Block(pos)
 		if explodable, ok := bl.(Explodable); ok {
-			explodable.Explode(src, pos, tx, c)
+			explodable.Explode(src, pos, tx)
 		} else if breakable, ok := bl.(Breakable); ok {
 			// Clear the block first so break handlers see the post-break world, this is required by things such as redstone updates.
 			tx.SetBlock(pos, nil, nil)

--- a/server/block/tnt.go
+++ b/server/block/tnt.go
@@ -53,7 +53,7 @@ func (t TNT) Ignite(pos cube.Pos, tx *world.Tx, _ world.Entity) bool {
 }
 
 // Explode ...
-func (t TNT) Explode(_ world.ExplosionSource, pos cube.Pos, tx *world.Tx, _ ExplosionConfig) {
+func (t TNT) Explode(_ world.ExplosionSource, pos cube.Pos, tx *world.Tx) {
 	spawnTnt(pos, tx, time.Second/2+time.Duration(rand.IntN(int(time.Second+time.Second/2))))
 }
 

--- a/server/world/explosion.go
+++ b/server/world/explosion.go
@@ -10,7 +10,8 @@ const defaultExplosionSize = 4
 
 // ExplosionSource represents the source of an explosion.
 type ExplosionSource interface {
-	// Position returns the position at the centre of the explosion.
+	// Position returns the position at the centre of the explosion. It must
+	// return the same position for the duration of an explosion.
 	Position() mgl64.Vec3
 	// Size returns the radius which entities/blocks are affected within.
 	Size() float64


### PR DESCRIPTION
One more for df-mc/dragonfly#1343, following on from #3.

### `Explodable` still received an `ExplosionConfig` — and a stale one

`Explode` snapshots `SpawnFire`/`ItemDropChance` into locals so the handler can mutate them, then dispatched blocks with the original `c`:

```go
spawnFire := c.SpawnFire
itemDropChance := c.ItemDropChance
if tx.World().Handler().HandleExplosion(ctx, src, ..., &itemDropChance, &spawnFire); ctx.Cancelled() { ... }
...
explodable.Explode(src, pos, tx, c)      // pre-handler config
...
if itemDropChance > r.Float64() { ... }  // post-handler value
```

So a block honouring `c.ItemDropChance` would disagree with what the explosion actually does. That's pre-existing rather than introduced here, but with `Size` moved to the source the config no longer carries anything a block should react to (`block.TNT` already ignored it), and this PR is the natural place to stop passing it. `Explodable` and `ExplodableEntity` now have matching shapes: source in, react.

If you'd rather keep the config available to blocks, the alternative is passing the post-handler values instead — but dropping it seemed cleaner while the API is already breaking.

Also added one sentence to `ExplosionSource.Position` requiring it to be stable for the duration of an explosion, since `Explode` computes impact against a snapshot while implementors may read live state.

`gofmt`, `go vet ./...` and `go test ./...` are clean.